### PR TITLE
Added possibility of dropping --router-profiling-path

### DIFF
--- a/megatron/arguments.py
+++ b/megatron/arguments.py
@@ -704,7 +704,7 @@ def _add_logging_args(parser):
                        help='Path to save the wandb results locally.')
     group.add_argument('--wandb-log-interval', type=int, default=1,
                        help='Report to wandb interval.')
-    group.add_argument('--router-profiling-path', type=str, default='',
+    group.add_argument('--router-profiling-path', type=str, default=None,
                        help='Path to save the expert statistics.')
     group.add_argument('--router-profiling-interval', type=int, default=None,
                        help='Number of iterations after which it saves expert statistics.')

--- a/megatron/initialize.py
+++ b/megatron/initialize.py
@@ -91,9 +91,10 @@ def initialize_megatron(
         if args.tp_comm_overlap:
            _initialize_tp_communicators()
 
-    dir_path = os.path.join(args.router_profiling_path)
-    if not os.path.exists(dir_path) and torch.distributed.get_rank() == 0:
-        os.makedirs(dir_path)
+    if args.router_profiling_path is not None and torch.distributed.get_rank() == 0:
+        dir_path = os.path.join(args.router_profiling_path)
+        if not os.path.exists(dir_path):
+            os.makedirs(dir_path)
 
         # No continuation function
         return None


### PR DESCRIPTION
Added two small fixes so that --router-profiling-path is not necessary if one is not interested in router profiling